### PR TITLE
adding new specs

### DIFF
--- a/_specifications/Hardware.html
+++ b/_specifications/Hardware.html
@@ -1,0 +1,126 @@
+---
+description: This Hardware profile specification presents a an abstract representation
+  of hardware used in a computational environment.
+edit_url: https://github.com/openschemas/specifications/tree/master/Hardware/specification.html
+gh_folder: https://github.com/openschemas/specifications/tree/master/Hardware
+gh_tasks: https://github.com/openschemas/specifications/labels/type%3A%20Hardware
+hierarchy:
+- Thing
+mapping:
+- bsc_description: The additional type defined by https://github.com/Vocamp/computationalEnvironmentODP/blob/master/data/ComputationalEnvironment.rdf
+  cardinality: ONE
+  controlled_vocab: https://github.com/Vocamp/computationalEnvironmentODP/blob/master/data/ComputationalEnvironment.rdf
+  description: An additional type for the item, typically used for adding more specific
+    types from external vocabularies in microdata syntax. This is a relationship between
+    something and a class that the thing is in. In RDFa syntax, it is better to use
+    the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org
+    tools may have only weaker understanding of extra types, in particular those defined
+    externally.
+  example: ''
+  expected_types:
+  - URL
+  marginality: Optional
+  parent: Thing
+  property: additionalType
+  type: external
+  type_url: http://dase.cs.wright.edu/ontologies/ComputationalEnvironment#Hardware
+- bsc_description: ''
+  cardinality: MANY
+  controlled_vocab: ''
+  description: An alias for the item.
+  example: ''
+  expected_types:
+  - Text
+  marginality: Recommended
+  parent: Thing
+  property: alternateName
+  type: ''
+  type_url: ''
+- bsc_description: A description of the hardware
+  cardinality: ONE
+  controlled_vocab: ''
+  description: A description of the item.
+  example: ''
+  expected_types:
+  - Text
+  marginality: Minimum
+  parent: Thing
+  property: description
+  type: ''
+  type_url: ''
+- bsc_description: The identifier of the hardware, likely a hardware address or similar.
+  cardinality: ONE
+  controlled_vocab: ''
+  description: The identifier property represents any kind of identifier for any kind
+    of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs,
+    GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing
+    many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background
+    notes</a> for more details.
+  example: ''
+  expected_types:
+  - PropertyValue
+  - Text
+  - URL
+  marginality: Recommended
+  parent: Thing
+  property: identifier
+  type: ''
+  type_url: ''
+- bsc_description: The name of the hardware
+  cardinality: ONE
+  controlled_vocab: ''
+  description: The name of the item.
+  example: ''
+  expected_types:
+  - Text
+  marginality: Minimum
+  parent: Thing
+  property: name
+  type: ''
+  type_url: ''
+- bsc_description: A url associated with the hardware.
+  cardinality: ONE
+  controlled_vocab: ''
+  description: URL of the item.
+  example: ''
+  expected_types:
+  - URL
+  marginality: Minimum
+  parent: Thing
+  property: url
+  type: ''
+  type_url: ''
+name: Hardware
+parent_type: Thing
+spec_info:
+  description: This Hardware profile specification presents a an abstract representation
+    of hardware used in a computational environment.
+  full_example: https://www.github.com/openschemas/specifications/tree/master/Hardware/examples/
+  version: 0.0.1
+  version_date: 20181005T011729
+spec_type: Profile
+status: revision
+subtitle: Openschemas specification to describe a hardware component of a computational
+  system
+use_cases_url: https://www.github.com/openschemas/spec-hardware
+version: 0.0.1
+---
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+         <div class="wrapper">
+            <div id="main-content-wrapper" class="outer">
+               <section id="main_content" class="inner">
+                  {% include profile_start.html %}
+                  {% include specification_table.html %}
+               </section>
+            </div>
+         </div>
+      </div>
+      {% include footer.html %}
+   </body>
+</html>

--- a/_specifications/Hardware.html
+++ b/_specifications/Hardware.html
@@ -1,8 +1,8 @@
 ---
 description: This Hardware profile specification presents a an abstract representation
   of hardware used in a computational environment.
-edit_url: https://github.com/openschemas/specifications/tree/master/Hardware/specification.html
-gh_folder: https://github.com/openschemas/specifications/tree/master/Hardware
+edit_url: https://github.com/openschemas/spec-hardware/blob/gh-pages/_specifications/Hardware.html
+gh_folder: https://github.com/openschemas/spec-hardware
 gh_tasks: https://github.com/openschemas/specifications/labels/type%3A%20Hardware
 hierarchy:
 - Thing
@@ -95,7 +95,7 @@ parent_type: Thing
 spec_info:
   description: This Hardware profile specification presents a an abstract representation
     of hardware used in a computational environment.
-  full_example: https://www.github.com/openschemas/specifications/tree/master/Hardware/examples/
+  full_example: https://www.github.com/openschemas/spec-hardware
   version: 0.0.1
   version_date: 20181005T011729
 spec_type: Profile

--- a/_specifications/OperatingSystem.html
+++ b/_specifications/OperatingSystem.html
@@ -1,0 +1,125 @@
+---
+description: This Virtualization profile specification presents a an abstract representation
+  of virtualization used in a computational environment.
+edit_url: https://github.com/openschemas/specifications/tree/master/OperatingSystem/specification.html
+gh_folder: https://github.com/openschemas/specifications/tree/master/OperatingSystem
+gh_tasks: https://github.com/openschemas/specifications/labels/type%3A%20OperatingSystem
+hierarchy:
+- Thing
+mapping:
+- bsc_description: The additional type is defined at http://dase.cs.wright.edu/ontologies/ComputationalEnvironment#OperatingSystem
+  cardinality: ONE
+  controlled_vocab: https://github.com/Vocamp/computationalEnvironmentODP/blob/master/data/ComputationalEnvironment.rdf
+  description: An additional type for the item, typically used for adding more specific
+    types from external vocabularies in microdata syntax. This is a relationship between
+    something and a class that the thing is in. In RDFa syntax, it is better to use
+    the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org
+    tools may have only weaker understanding of extra types, in particular those defined
+    externally.
+  example: ''
+  expected_types:
+  - URL
+  marginality: Optional
+  parent: Thing
+  property: additionalType
+  type: external
+  type_url: http://dase.cs.wright.edu/ontologies/ComputationalEnvironment#OperatingSystem
+- bsc_description: ''
+  cardinality: MANY
+  controlled_vocab: ''
+  description: An alias for the item.
+  example: ''
+  expected_types:
+  - Text
+  marginality: Recommended
+  parent: Thing
+  property: alternateName
+  type: ''
+  type_url: ''
+- bsc_description: A description of the operating system
+  cardinality: ONE
+  controlled_vocab: ''
+  description: A description of the item.
+  example: ''
+  expected_types:
+  - Text
+  marginality: Minimum
+  parent: Thing
+  property: description
+  type: ''
+  type_url: ''
+- bsc_description: An identifier for the operating system
+  cardinality: ONE
+  controlled_vocab: ''
+  description: The identifier property represents any kind of identifier for any kind
+    of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs,
+    GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing
+    many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background
+    notes</a> for more details.
+  example: ''
+  expected_types:
+  - PropertyValue
+  - Text
+  - URL
+  marginality: Recommended
+  parent: Thing
+  property: identifier
+  type: ''
+  type_url: ''
+- bsc_description: The name of the operating system
+  cardinality: ONE
+  controlled_vocab: ''
+  description: The name of the item.
+  example: ''
+  expected_types:
+  - Text
+  marginality: Minimum
+  parent: Thing
+  property: name
+  type: ''
+  type_url: ''
+- bsc_description: A url associated with the operating system
+  cardinality: ONE
+  controlled_vocab: ''
+  description: URL of the item.
+  example: ''
+  expected_types:
+  - URL
+  marginality: Minimum
+  parent: Thing
+  property: url
+  type: ''
+  type_url: ''
+name: OperatingSystem
+parent_type: Thing
+spec_info:
+  description: This Virtualization profile specification presents a an abstract representation
+    of virtualization used in a computational environment.
+  full_example: https://www.github.com/openschemas/specifications/tree/master/OperatingSystem/examples/
+  version: 0.0.1
+  version_date: 20181008T140519
+spec_type: Profile
+status: revision
+subtitle: Openschemas specification to describe an operating system
+use_cases_url: https://www.github.com/openschemas/spec-operatingsystem
+version: 0.0.1
+---
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+         <div class="wrapper">
+            <div id="main-content-wrapper" class="outer">
+               <section id="main_content" class="inner">
+                  {% include profile_start.html %}
+                  {% include specification_table.html %}
+               </section>
+            </div>
+         </div>
+      </div>
+      {% include footer.html %}
+   </body>
+</html>

--- a/_specifications/OperatingSystem.html
+++ b/_specifications/OperatingSystem.html
@@ -1,8 +1,8 @@
 ---
 description: This Virtualization profile specification presents a an abstract representation
   of virtualization used in a computational environment.
-edit_url: https://github.com/openschemas/specifications/tree/master/OperatingSystem/specification.html
-gh_folder: https://github.com/openschemas/specifications/tree/master/OperatingSystem
+edit_url: https://github.com/openschemas/spec-operatingsystem/blob/gh-pages/_specifications/OperatingSystem.html
+gh_folder: https://github.com/openschemas/spec-operatingsystem
 gh_tasks: https://github.com/openschemas/specifications/labels/type%3A%20OperatingSystem
 hierarchy:
 - Thing
@@ -95,7 +95,7 @@ parent_type: Thing
 spec_info:
   description: This Virtualization profile specification presents a an abstract representation
     of virtualization used in a computational environment.
-  full_example: https://www.github.com/openschemas/specifications/tree/master/OperatingSystem/examples/
+  full_example: https://www.github.com/openschemas/spec-operatingsystem
   version: 0.0.1
   version_date: 20181008T140519
 spec_type: Profile

--- a/_specifications/Virtualization.html
+++ b/_specifications/Virtualization.html
@@ -1,8 +1,8 @@
 ---
 description: This Virtualization profile specification presents a an abstract representation
   of virtualization used in a computational environment.
-edit_url: https://github.com/openschemas/specifications/tree/master/Virtualization/specification.html
-gh_folder: https://github.com/openschemas/specifications/tree/master/Virtualization
+edit_url: https://github.com/openschemas/spec-virtualization/blob/gh-pages/_specifications/Virtualization.html
+gh_folder: https://github.com/openschemas/spec-virtualization
 gh_tasks: https://github.com/openschemas/specifications/labels/type%3A%20Virtualization
 hierarchy:
 - Thing
@@ -95,7 +95,7 @@ parent_type: Thing
 spec_info:
   description: This Virtualization profile specification presents a an abstract representation
     of virtualization used in a computational environment.
-  full_example: https://www.github.com/openschemas/specifications/tree/master/Virtualization/examples/
+  full_example: https://www.github.com/openschemas/spec-virtualization
   version: 0.0.1
   version_date: 20181008T130959
 spec_type: Profile

--- a/_specifications/Virtualization.html
+++ b/_specifications/Virtualization.html
@@ -1,0 +1,125 @@
+---
+description: This Virtualization profile specification presents a an abstract representation
+  of virtualization used in a computational environment.
+edit_url: https://github.com/openschemas/specifications/tree/master/Virtualization/specification.html
+gh_folder: https://github.com/openschemas/specifications/tree/master/Virtualization
+gh_tasks: https://github.com/openschemas/specifications/labels/type%3A%20Virtualization
+hierarchy:
+- Thing
+mapping:
+- bsc_description: The additional type is defined at http://security.polito.it/ontology/
+  cardinality: ONE
+  controlled_vocab: https://github.com/Vocamp/computationalEnvironmentODP/blob/master/data/ComputationalEnvironment.rdf
+  description: An additional type for the item, typically used for adding more specific
+    types from external vocabularies in microdata syntax. This is a relationship between
+    something and a class that the thing is in. In RDFa syntax, it is better to use
+    the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org
+    tools may have only weaker understanding of extra types, in particular those defined
+    externally.
+  example: ''
+  expected_types:
+  - URL
+  marginality: Optional
+  parent: Thing
+  property: additionalType
+  type: external
+  type_url: http://security.polito.it/ontology/
+- bsc_description: ''
+  cardinality: MANY
+  controlled_vocab: ''
+  description: An alias for the item.
+  example: ''
+  expected_types:
+  - Text
+  marginality: Recommended
+  parent: Thing
+  property: alternateName
+  type: ''
+  type_url: ''
+- bsc_description: A description of the virtualization technology
+  cardinality: ONE
+  controlled_vocab: ''
+  description: A description of the item.
+  example: ''
+  expected_types:
+  - Text
+  marginality: Minimum
+  parent: Thing
+  property: description
+  type: ''
+  type_url: ''
+- bsc_description: An identifier for the virtualization technology.
+  cardinality: ONE
+  controlled_vocab: ''
+  description: The identifier property represents any kind of identifier for any kind
+    of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs,
+    GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing
+    many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background
+    notes</a> for more details.
+  example: ''
+  expected_types:
+  - PropertyValue
+  - Text
+  - URL
+  marginality: Recommended
+  parent: Thing
+  property: identifier
+  type: ''
+  type_url: ''
+- bsc_description: The name of the virtualization technology
+  cardinality: ONE
+  controlled_vocab: ''
+  description: The name of the item.
+  example: ''
+  expected_types:
+  - Text
+  marginality: Minimum
+  parent: Thing
+  property: name
+  type: ''
+  type_url: ''
+- bsc_description: A url associated with the virtualization technology.
+  cardinality: ONE
+  controlled_vocab: ''
+  description: URL of the item.
+  example: ''
+  expected_types:
+  - URL
+  marginality: Minimum
+  parent: Thing
+  property: url
+  type: ''
+  type_url: ''
+name: Virtualization
+parent_type: Thing
+spec_info:
+  description: This Virtualization profile specification presents a an abstract representation
+    of virtualization used in a computational environment.
+  full_example: https://www.github.com/openschemas/specifications/tree/master/Virtualization/examples/
+  version: 0.0.1
+  version_date: 20181008T130959
+spec_type: Profile
+status: revision
+subtitle: Openschemas specification to describe Virtualization technology
+use_cases_url: https://www.github.com/openschemas/spec-virtualization
+version: 0.0.1
+---
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+         <div class="wrapper">
+            <div id="main-content-wrapper" class="outer">
+               <section id="main_content" class="inner">
+                  {% include profile_start.html %}
+                  {% include specification_table.html %}
+               </section>
+            </div>
+         </div>
+      </div>
+      {% include footer.html %}
+   </body>
+</html>


### PR DESCRIPTION
This will add skeleton (bases) for:

 - [Hardware](https://openschemas.github.io/spec-hardware)
 - [Virtualization](https://openschemas.github.io/spec-virtualization)
 - [OperatingSystem](https://openschemas.github.io/spec-operatingsystem)

I don't intend for these to be anything more than skeletons - they mostly need to be defined for Container to build from, and others with expertise can contribute in the future.