### PR TITLE
making containerImage property lowercase

### DIFF
--- a/_specifications/ContainerRecipe.html
+++ b/_specifications/ContainerRecipe.html
@@ -89,7 +89,7 @@ mapping:
   - ContainerImage
   marginality: Recommended
   parent: ContainerRecipe
-  property: ContainerImage
+  property: containerImage
   type: ''
   type_url: ''
 - bsc_description: ''


### PR DESCRIPTION
This will address #10 - @stain to verify, we just need to make the property lowercase, and not the many references to parent: ContainerImage (that refer to the type?). And another clarification - the property containerImage will refer to another object with type ContainerImage?

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>